### PR TITLE
Merchant item new form

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -29,6 +29,7 @@ class MerchantItemsController < ApplicationController
 
   def new
     @merchant = Merchant.find(params[:merchant_id])
+    @item = Item.create()
   end
 
   def create
@@ -40,6 +41,6 @@ class MerchantItemsController < ApplicationController
     private
 
     def item_params
-      params.permit(:name, :description, :unit_price, :status)
+      params.require(:item).permit(:name, :description, :unit_price, :status)
     end
 end

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -19,10 +19,10 @@ class MerchantItemsController < ApplicationController
     merchant = Merchant.find(params[:merchant_id])
     item = Item.find(params[:id])
     if params[:status]
-      item.update(item_params)
+      item.update(item_params_2)
       redirect_to "/merchants/#{merchant.id}/items"
     else
-      item.update(item_params)
+      item.update(item_params_2)
       redirect_to "/merchants/#{merchant.id}/items/#{item.id}",  notice: "Item Successfully Updated"
     end
   end
@@ -34,7 +34,7 @@ class MerchantItemsController < ApplicationController
 
   def create
     merchant = Merchant.find(params[:merchant_id])
-    item = merchant.items.create!(item_params)
+    merchant.items.create!(item_params)
     redirect_to "/merchants/#{merchant.id}/items"
   end
 
@@ -42,5 +42,9 @@ class MerchantItemsController < ApplicationController
 
     def item_params
       params.require(:item).permit(:name, :description, :unit_price, :status)
+    end
+
+    def item_params_2
+      params.permit(:name, :description, :unit_price, :status)
     end
 end

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -18,11 +18,11 @@ class MerchantItemsController < ApplicationController
   def update
     merchant = Merchant.find(params[:merchant_id])
     item = Item.find(params[:id])
-    if params[:status]
-      item.update(item_params_2)
+    if item_params[:status]
+      item.update(item_params)
       redirect_to "/merchants/#{merchant.id}/items"
     else
-      item.update(item_params_2)
+      item.update(item_params)
       redirect_to "/merchants/#{merchant.id}/items/#{item.id}",  notice: "Item Successfully Updated"
     end
   end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -5,8 +5,10 @@
   <% @enabled_items_array.each do |item| %>
     <div class="<%= "item_#{item.id}" %>">
       <h3><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></h3>
-      <h4><%= button_to "Disable #{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: {status: "Disabled"} %></h4>
-      <hr>
+      <%= form_with model: [@merchant, item], local: true do |form| %>
+        <%= form.hidden_field :status, value: "Disabled" %>
+        <%= form.submit "Disable #{item.name}"%>
+      <% end %>
     </div>
   <% end %>
 
@@ -14,7 +16,10 @@
   <% @disabled_items_array.each do |item| %>
     <div class="<%= "item_#{item.id}" %>">
       <h3><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></h3>
-      <h4><%= button_to "Enable #{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: {status: "Enabled"} %></h4>
+      <%= form_with model: [@merchant, item], local: true do |form| %>
+        <%= form.hidden_field :status, value: "Enabled" %>
+        <%= form.submit "Enable #{item.name}"%>
+      <% end %>
       <hr>
     </div>
   <% end %>

--- a/app/views/merchant_items/new.html.erb
+++ b/app/views/merchant_items/new.html.erb
@@ -1,12 +1,12 @@
 <h1>New Item for <%= @merchant.name %></h1>
 <div id=create_item>
-  <%= form_with url: "/merchants/#{@merchant.id}/items", method: :post, local: true do |form| %>
-    <%= form.label :name, "Name:" %>
-    <%= form.text_field :name %>
-    <%= form.label :description, "Description:" %>
-    <%= form.text_field :description %>
-    <%= form.label :unit_price, "Unit Price:" %>
-    <%= form.text_field :unit_price %>
-    <%= form.submit 'Submit' %>
+  <%= form_with model: [@merchant, @item], local: true do |form|%>
+  <%= form.label :name, "Name:" %>
+  <%= form.text_field :name %>
+  <%= form.label :description, "Description:" %>
+  <%= form.text_field :description %>
+  <%= form.label :unit_price, "Unit Price:" %>
+  <%= form.text_field :unit_price %>
+  <%= form.submit%>
   <% end %>
 </div>

--- a/spec/features/merchants/items/create_spec.rb
+++ b/spec/features/merchants/items/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Merchant Item Create page" do
       fill_in "Name:", with: "Paul's Item"
       fill_in "Description", with: "An item from Paul"
       fill_in "Unit Price:", with: 1000
-      click_button "Submit"
+      click_button "Create Item"
     end
 
     expect(current_path).to eq("/merchants/#{merchant1.id}/items")

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Merchant Items Index page' do
     expect(page).to_not have_content('Eric')
   end
 
-  it "Has buttons next to each item to enable or disable. Both buttons refresh the page with updated status" do
+  it "Has button next to each item to enable. Buttons refreshes the page with updated enabled status" do
     merchant = create(:merchant)
     item1 = create(:item, merchant: merchant, name: "Paul")
     item2 = create(:item, merchant: merchant, name: "Leland")
@@ -28,6 +28,23 @@ RSpec.describe 'Merchant Items Index page' do
 
       item2.reload
       expect(item2.status).to eq("Enabled")
+    end
+  end
+
+  it "Has button next to each item to disable. Buttons refreshes the page with updated disabled status" do
+    merchant = create(:merchant)
+    item1 = create(:item, merchant: merchant, name: "Paul")
+    item2 = create(:item, merchant: merchant, name: "Leland", status: "Enabled")
+    visit "/merchants/#{merchant.id}/items"
+    within("div.item_#{item2.id}") do
+      expect(page).to have_button("Disable")
+
+      click_button("Disable")
+
+      expect(current_path).to eq("/merchants/#{merchant.id}/items")
+
+      item2.reload
+      expect(item2.status).to eq("Disabled")
     end
   end
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'Merchant Items Index page' do
       expect(current_path).to eq("/merchants/#{merchant.id}/items")
 
       item2.reload
-
       expect(item2.status).to eq("Enabled")
     end
   end


### PR DESCRIPTION
- refactored merchant_items_new form to use form_with :model
- STRANGE BUG: new form needed item_params to use the params.require(:item).permit, but update form still needed older params.permit syntax. I created two methods so we could use either version. 
- In future, let's try to figure out why merchant_items update form_with: model is not doing what we expect it to.